### PR TITLE
Added vbat_offset command

### DIFF
--- a/tinyscpi/dictionaries/scpi_valid_dict.py
+++ b/tinyscpi/dictionaries/scpi_valid_dict.py
@@ -53,5 +53,6 @@ validCommandTable = {'*IDN?': [],
                      'MEASure:SWEep:TIME': [['int', 0, 600]],
                      'MEASure:SCAN:RAW:START': [['int', 0, 350000000], ['int', 0, 350000000], ['int', 0, 2147483647]],
                      'CAPTure': [],
-                     'SYSTem:THREADs?': []
+                     'SYSTem:THREADs?': [],
+                     'SYSTem:VOLTage:DC:OFFSet':[['int', 0, 4095]]
                     }


### PR DESCRIPTION
Alters the display of the battery value on the TinySA. Comments on different value can be found on "Info on SCPI Command Functionality" document.